### PR TITLE
Add indices method like in Kotlin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export {default as includes} from './includes';
 export {default as index} from './index!';
 export {default as indexOf} from './indexOf';
 export {default as indexRange} from './indexRange';
+export {default as indices} from './indices';
 export {default as init} from './init';
 export {default as interleave} from './interleave';
 export {default as intermix} from './intermix';

--- a/src/indices.ts
+++ b/src/indices.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a list of valid indices for the iterable.
+ * @param x an iterable
+ */
+function* indices<T>(x: Iterable<T>): IterableIterator<number> {
+  let i = -1;
+  for(const _ of x)
+    yield ++i;
+}
+export default indices;


### PR DESCRIPTION
Hi. This method will allow iterating over the iterable indices like in Kotlin https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/indices.html. Yes, you can use `entries` method, but if I want to get the indices only, I have to apply `map` first, which is inconvenient and adds an extra-boilerplate.